### PR TITLE
fix: use CREEK_PACKAGES_TOKEN secret for GitHub Packages Dependabot auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ registries:
     type: maven-repository
     url: https://maven.pkg.github.com/creek-service/
     username: x-access-token
-    password: ${{secrets.GITHUB_TOKEN}}
+    password: ${{secrets.CREEK_PACKAGES_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
This PR fixes the Dependabot configuration to use the correct secret name for GitHub Packages authentication.

**Changes:**
- Replace `${{secrets.GITHUB_TOKEN}}` with `${{secrets.CREEK_PACKAGES_TOKEN}}` in `.github/dependabot.yml`

**Why:**
GITHUB_TOKEN is not a valid Dependabot secret name since Dependabot secret names cannot start with GITHUB_. The CREEK_PACKAGES_TOKEN is an org-level Dependabot secret with read:packages scope for the creek-service organization.